### PR TITLE
Document default `rows` limit when not specified

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1689,7 +1689,7 @@ def package_search(context, data_dict):
         sort-orderings.
     :type sort: string
     :param rows: the number of matching rows to return. There is a hard limit
-        of 1000 datasets per query.
+        of 1000 datasets per query. Optional. Default is 10.
     :type rows: int
     :param start: the offset in the complete result for where the set of
         returned datasets should begin.


### PR DESCRIPTION
By default the API returns results from the top 10 datasets only. This adds this note to the documentation.

Fixes #

### Proposed fixes:

Added a note on the parameter notifying users of the 10 row default limit.

### Features:

- [ ] includes tests covering changes
- [ x ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
